### PR TITLE
Remove trailing denominator from displayed ratings

### DIFF
--- a/script.js
+++ b/script.js
@@ -316,7 +316,6 @@ function renderReadList(books) {
 
       ratingEl.appendChild(stars);
       ratingEl.appendChild(label);
-      ratingEl.appendChild(document.createTextNode(" / 5"));
       info.appendChild(ratingEl);
     }
 


### PR DESCRIPTION
## Summary
- stop appending the `/ 5` suffix to rendered book ratings so only the numeric score is shown

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbb0398374832ba6a76a15cb444c52