### PR TITLE
Enhance star rating contrast

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -277,22 +277,21 @@ main.container {
   gap: 0.3rem;
 }
 
+
 .star-rating {
   position: relative;
   display: inline-block;
   font-size: 1.1rem;
   line-height: 1;
-  color: rgba(255, 255, 255, 0.6);
-  background: linear-gradient(90deg, var(--pink-400), var(--pink-500));
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
+  color: transparent;
 }
 
 .star-rating::before {
   content: "★★★★★";
-  color: rgba(255, 255, 255, 0.25);
-  -webkit-text-fill-color: rgba(255, 255, 255, 0.25);
+  color: rgba(255, 161, 203, 0.3);
+  -webkit-text-fill-color: transparent;
+  -webkit-text-stroke: 1.1px rgba(255, 161, 203, 0.9);
+  text-shadow: 0 0 1px rgba(255, 161, 203, 0.7);
 }
 
 .star-rating::after {
@@ -305,6 +304,7 @@ main.container {
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
+  -webkit-text-stroke: 1.1px rgba(255, 161, 203, 0.35);
   width: var(--fill, 0%);
   overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- restyle the star rating widget so unfilled segments use a pink outline with transparent centers
- retain the gradient-filled overlay with a subtle stroke to improve legibility of partial scores

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dbb09f32ec832ba2a07a828b2bb0f2