### PR TITLE
Adjust read book meeting date formatting

### DIFF
--- a/script.js
+++ b/script.js
@@ -292,11 +292,11 @@ function renderReadList(books) {
       info.appendChild(note);
     }
 
-    const meeting = formatMeetingDate(book.meetingDateRaw);
-    if (meeting) {
+    const meetingDate = parseDate(book.meetingDateRaw);
+    if (meetingDate) {
       const meetingEl = document.createElement("p");
       meetingEl.className = "meeting";
-      meetingEl.textContent = meeting;
+      meetingEl.textContent = formatMonthYear(meetingDate);
       info.appendChild(meetingEl);
     }
 
@@ -406,6 +406,12 @@ function formatMeetingDate(dateString) {
   const date = parseDate(dateString);
   if (!date) return "";
   return `Porozmawiamy o książce: ${formatDate(date)}`;
+}
+
+function formatMonthYear(date) {
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const year = date.getFullYear();
+  return `${month}.${year}`;
 }
 
 function parseDate(input) {


### PR DESCRIPTION
## Summary
- remove the "Porozmawiamy o książce" prefix from read book cards
- show only month and year for past meeting dates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd958e0df8832bbcb3ecb4c6f10b89