### PR TITLE
Align read list cards to start from the top

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -203,6 +203,7 @@ main.container {
   padding: 1.2rem;
   box-shadow: var(--shadow-soft);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  align-items: flex-start;
 }
 
 .book-card:hover,
@@ -243,7 +244,13 @@ main.container {
 .book-info {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.6rem;
+  justify-content: flex-start;
+}
+
+.book-info > * {
+  margin: 0;
+  line-height: 1.5;
 }
 
 .book-info h3 {


### PR DESCRIPTION
## Summary
- align the text column in read-list cards to the top for consistent layout
- increase spacing and line-height in the read section details to keep entries readable

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd97f3e0f0832b8125cbb2de6cc094