### PR TITLE
Remove redundant section update notices

### DIFF
--- a/script.js
+++ b/script.js
@@ -172,7 +172,7 @@ function renderNowReading(books) {
     return;
   }
 
-  nowReadingStatus.textContent = "Zaktualizowano.";
+  nowReadingStatus.textContent = "";
   const card = document.createElement("article");
   card.className = "now-reading-card";
 
@@ -244,7 +244,7 @@ function renderReadList(books) {
     return;
   }
 
-  readStatus.textContent = "Zaktualizowano.";
+  readStatus.textContent = "";
 
   readBooks.forEach((book) => {
     const item = document.createElement("article");


### PR DESCRIPTION
## Summary
- clear the section status text once data loads to avoid repeated "Zaktualizowano." messages

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de435cd4cc832b82fedcd40cdf4339