### PR TITLE
Improve star rating contrast

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -309,10 +309,8 @@ main.container {
 
 .star-rating::before {
   content: "★★★★★";
-  color: rgba(255, 161, 203, 0.3);
-  -webkit-text-fill-color: transparent;
-  -webkit-text-stroke: 1.1px rgba(255, 161, 203, 0.9);
-  text-shadow: 0 0 1px rgba(255, 161, 203, 0.7);
+  color: #ff99ac;
+  -webkit-text-stroke: 1.1px #ff99ac;
 }
 
 .star-rating::after {
@@ -321,11 +319,11 @@ main.container {
   left: 0;
   top: 0;
   color: transparent;
-  background: linear-gradient(90deg, var(--pink-400), var(--pink-500));
+  background: #e30b5d;
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
-  -webkit-text-stroke: 1.1px rgba(255, 161, 203, 0.35);
+  -webkit-text-stroke: 1.1px rgba(227, 11, 93, 0.35);
   width: var(--fill, 0%);
   overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- update the star rating component colors to use #E30B5D for filled stars and #FF99AC for empty stars
- enhance contrast between filled and unfilled stars for better readability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de44b27794832ba592612159c95523