### PR TITLE
Refine genre tags styling and parsing

### DIFF
--- a/script.js
+++ b/script.js
@@ -106,6 +106,7 @@ function toBooks(rows) {
       return {
         title: getValue(record, 0, "Tytuł", "Title"),
         author: getValue(record, 1, "Autor", "Author"),
+        genre: getValue(record, undefined, "Gatunek", "Gatunki", "Genre", "Category"),
         note: getValue(
           record,
           2,
@@ -203,6 +204,14 @@ function renderNowReading(books) {
     details.appendChild(author);
   }
 
+  const genreTags = createGenreTags(currentBook.genre);
+  if (genreTags.length) {
+    const genreContainer = document.createElement("div");
+    genreContainer.className = "genre-tags";
+    genreTags.forEach((tag) => genreContainer.appendChild(tag));
+    details.appendChild(genreContainer);
+  }
+
   if (currentBook.picker) {
     const picker = document.createElement("p");
     picker.className = "picker";
@@ -278,6 +287,14 @@ function renderReadList(books) {
       info.appendChild(author);
     }
 
+    const genreTags = createGenreTags(book.genre);
+    if (genreTags.length) {
+      const genreContainer = document.createElement("div");
+      genreContainer.className = "genre-tags";
+      genreTags.forEach((tag) => genreContainer.appendChild(tag));
+      info.appendChild(genreContainer);
+    }
+
     if (book.picker) {
       const picker = document.createElement("p");
       picker.className = "picker";
@@ -340,6 +357,20 @@ function createCoverElement(rawUrl, title, placeholderClass) {
     wrapper.appendChild(placeholder);
   }
   return wrapper;
+}
+
+function createGenreTags(value) {
+  if (!value) return [];
+  const parts = value
+    .split(/[,/|#]/)
+    .map((part) => part.replace(/^#+/, "").trim())
+    .filter(Boolean);
+  return parts.map((part) => {
+    const tag = document.createElement("span");
+    tag.className = "genre-tag";
+    tag.textContent = part;
+    return tag;
+  });
 }
 
 function initialsFromTitle(title = "") {

--- a/styles.css
+++ b/styles.css
@@ -140,6 +140,26 @@ main.container {
   gap: 1.5rem;
 }
 
+.genre-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.genre-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(64, 38, 59, 0.92);
+  color: rgba(255, 255, 255, 0.92);
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  box-shadow: 0 6px 14px rgba(64, 38, 59, 0.25);
+}
+
 .now-reading-details h3 {
   font-size: clamp(2rem, 3vw, 2.6rem);
   margin: 0;


### PR DESCRIPTION
## Summary
- strip leading hash symbols when parsing genre values into tags
- tweak genre tag styling to use a dark background with light text for contrast

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de45ae6210832bb813b2a0cd056c34