### PR TITLE
Remove unused note handling from book cards

### DIFF
--- a/script.js
+++ b/script.js
@@ -107,16 +107,6 @@ function toBooks(rows) {
         title: getValue(record, 0, "Tytuł", "Title"),
         author: getValue(record, 1, "Autor", "Author"),
         genre: getValue(record, undefined, "Gatunek", "Gatunki", "Genre", "Category"),
-        note: getValue(
-          record,
-          2,
-          "Notatka",
-          "Notatki",
-          "Opis",
-          "Note",
-          "Notes",
-          "Description"
-        ),
         cover: getValue(
           record,
           3,
@@ -300,14 +290,6 @@ function renderReadList(books) {
       picker.className = "picker";
       picker.innerHTML = `<span class="meta-label">Wybrała:</span> ${book.picker}`;
       info.appendChild(picker);
-    }
-
-    const noteText = book.note?.trim();
-    if (noteText && !isValidHttpUrl(noteText) && noteText !== extractImageUrl(book.cover).trim()) {
-      const note = document.createElement("p");
-      note.className = "note";
-      note.textContent = noteText;
-      info.appendChild(note);
     }
 
     const meetingDate = parseDate(book.meetingDateRaw);

--- a/styles.css
+++ b/styles.css
@@ -304,7 +304,6 @@ main.container {
 
 .book-info .author,
 .book-info .picker,
-.book-info .note,
 .book-info .meeting,
 .book-info .rating {
   font-size: 0.95rem;


### PR DESCRIPTION
## Summary
- stop populating the unused note property when mapping spreadsheet rows
- remove the note rendering block from finished book cards and clean up related styles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfd7ed0078832ba3aceb00f0509373