### PR TITLE
Align Now Reading card layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -136,8 +136,12 @@ main.container {
 .now-reading-details {
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  gap: 1.5rem;
+  gap: 0.6rem;
+}
+
+.now-reading-details > :where(h3, p) {
+  margin: 0;
+  line-height: 1.5;
 }
 
 .genre-tags {
@@ -204,6 +208,7 @@ main.container {
 
 .meeting-date {
   margin-top: auto;
+  padding-top: 1rem;
   font-weight: 600;
 }
 


### PR DESCRIPTION
## Summary
- align the textual details in the Now Reading card with consistent top alignment and line spacing
- keep the meeting information anchored to the bottom while matching the typography used in the read list cards

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dff44081dc832b873bcaccaa417ec9