### PR TITLE
Add hover highlight to Now Reading titles

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -152,6 +152,11 @@ main.container {
   position: relative;
 }
 
+.now-reading-details a:hover,
+.now-reading-details a:focus-visible {
+  color: var(--pink-500);
+}
+
 .now-reading-details a::after {
   content: "";
   position: absolute;


### PR DESCRIPTION
## Summary
- apply the same pink accent color to Now Reading book titles when hovered or focused
- keep the existing underline effect while matching the styling of the Read section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee814a6478832babe3342d94f79e07